### PR TITLE
Actualizar poblacion

### DIFF
--- a/API/controllers/envioController.js
+++ b/API/controllers/envioController.js
@@ -234,3 +234,28 @@ exports.obtenerEnvios = async(req,res,next)=>{
         next();
     }
 }
+
+exports.obtenerEnvioId = async(req,res,next)=>{
+    try{
+        res.statusCode = 200;
+        res.setHeader('content-type', 'application/json');
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        console.log(req.query.idEnvio)
+        const envio = await Envio.findById(req.query.idEnvio);
+        console.log(typeof envio)
+        console.log(envio)
+        if(envio == null)
+        {
+            res.json({"mensaje":"Envio inexistente"})
+        }
+        else
+        {
+            res.json(envio)
+        }
+    }catch(error)
+    {
+        console.log(error);
+        next();
+    }
+}
+

--- a/API/controllers/informesController.js
+++ b/API/controllers/informesController.js
@@ -59,6 +59,7 @@ exports.registrarInforme = async (req,res,next) => {
                             nuevaEstadistica.dataCiudades[i].cantidades.enfermos += nuevoInforme.resumenCasos.cantidadEnfermos
                             nuevaEstadistica.dataCiudades[i].cantidades.recuperados += nuevoInforme.resumenCasos.cantidadCurados
                             nuevaEstadistica.dataCiudades[i].cantidades.muertos += nuevoInforme.resumenCasos.cantidadMuertos
+                            nuevaEstadistica.dataCiudades[i].poblacion -= nuevoInforme.resumenCasos.cantidadMuertos
                             nuevaEstadistica.totales.enfermos += nuevoInforme.resumenCasos.cantidadEnfermos
                             nuevaEstadistica.totales.recuperados += nuevoInforme.resumenCasos.cantidadCurados
                             nuevaEstadistica.totales.muertos += nuevoInforme.resumenCasos.cantidadMuertos

--- a/API/routes/index.js
+++ b/API/routes/index.js
@@ -22,6 +22,10 @@ router.get('/',(req,res)=>{
 
 //Envios
 // DOC STATUS: Complete 
+router.get('/envioId',
+    envioController.obtenerEnvioId
+    );
+
 router.get('/envios',
     envioController.obtenerEnvios
     );

--- a/API/serverless.yml
+++ b/API/serverless.yml
@@ -111,7 +111,28 @@ functions:
                     -
                         statusCode: "403"
                         responseBody:
-                            description: "Ocurre cuando se supera la cuota diaria"       
+                            description: "Ocurre cuando se supera la cuota diaria" 
+          - http:
+            path: /envioId
+            method: GET
+            cors: true
+            documentation:
+                summary: "Allows to find a envio by its mongo id"
+                queryParams:
+                    -
+                        name: "idEnvio"
+                        description: "Mongo ID for the envio object"
+                methodResponses:
+                    -
+                        statusCode: "200"
+                        responseBody:
+                            description: "a single envio"
+                        responseModels:
+                            "application/json" : "envio"
+                    -
+                        statusCode: "403"
+                        responseBody:
+                            description: "Ocurre cuando se supera la cuota diaria"
       - http:
           path: /register
           method: POST


### PR DESCRIPTION
Endpoint envioId, devuelve un envio pasando como parametro el id de mongo, actualizado serverless.
Se actualiza la poblacion de cada ciudad en caso de que existan muertos en un informe,